### PR TITLE
Note in version if working directory is dirty

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,6 +33,7 @@
 		<arg value="describe" />
 		<arg value="--always" />
 		<arg value="--abbrev=4" />
+		<arg value="--dirty" />
 	</exec>
 
 	<condition property="git.revision" value="${git.describe}" else="@unknown@">


### PR DESCRIPTION
This adds -dirty to the description if there are uncommitted changes in
the working directory when building
