### PR TITLE
Refactor Toadlet registration for readability.

### DIFF
--- a/src/plugins/WebOfTrust/ui/web/WebInterface.java
+++ b/src/plugins/WebOfTrust/ui/web/WebInterface.java
@@ -344,13 +344,16 @@ public class WebInterface {
 			new ConfigWebInterfaceToadlet(null, this, core, "Configuration")
 		));
 
+		/*
+		 * For backwards compatibility also register at the root. This must be before the other pages or it will
+		 * match all /WebOfTrust/ requests.
+		 */
+		// TODO: Skip by giving the navigation category the home path?
+		container.register(home, null, mURI + "/", true, true);
+
 		for (WebInterfaceToadlet toadlet : listed) {
 			registerMenu(container, toadlet);
 		}
-
-		// For backwards compatibility also register at the root.
-		// TODO: Skip by giving the navigation category the home path?
-		container.register(home, null, mURI + "/", true, true);
 
 		// Pages not listed in the menu:
 


### PR DESCRIPTION
This is a precursor to adding a login page equivalent to that in Freetalk. It moves repeated calls into methods and removes named instance where there are not needed.
