### PR TITLE
Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 
-sudo: false
+# We need Ubuntu 14.04 due to very new JUnit API which WoT needs
+sudo: required
+dist: trusty
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,14 @@ addons:
 cache:
   apt: true
   directories:
-  - fred/
+  - "$TRAVIS_BUILD_DIR"/../fred/
 
 before_install:
+  - cd "$TRAVIS_BUILD_DIR"/..
   - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; else cd fred ; git pull ; cd .. ; fi
-  - mkdir -p fred/lib/freenet/
   - if [ ! -e fred/lib/bcprov-jdk15on-154.jar ]; then cd fred/lib ; wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; cd ../.. ; fi
   - cd fred && ant clean && ant -Dlib.contrib.get=true -Dtest.skip=true && cd ..
+  - cd "$TRAVIS_BUILD_DIR"
 
 script: ant
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - mkdir -p fred/lib/freenet/
   - if [ ! -e fred/lib/bcprov-jdk15on-154.jar ]; then cd fred/lib ; wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; cd ../.. ; fi
   - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; else cd fred ; git pull ; cd .. ; fi
-  - if [ ! -e fred/dist/freenet.jar ]; then cd fred ; ant -Dlib.contrib.get=true -Dtest.skip=true ; cd .. ; fi
+  - cd fred && ant clean && ant -Dlib.contrib.get=true -Dtest.skip=true && cd ..
 
 script: ant
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: java
+
+sudo: false
+addons:
+  apt:
+    packages:
+    - ant
+    - ant-optional
+    - junit4
+    - libhamcrest-java
+
+cache:
+  apt: true
+  directories:
+  - lib/
+
+before_install:
+  - mkdir -p lib/freenet/ && cd lib/ && if [ ! -e bcprov-jdk15on-154.jar ]; then wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; fi ; cd ..
+
+script: ant -Dlib.contrib.get=true
+
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ cache:
 before_install:
   - mkdir -p fred/lib/freenet/
   - if [ ! -e fred/lib/bcprov-jdk15on-154.jar ]; then cd fred/lib ; wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; cd ../.. ; fi
-  - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; fi
-  - cd fred ; git pull ; cd ..
+  - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; else cd fred ; git pull ; cd .. ; fi
   - if [ ! -e fred/dist/freenet.jar ]; then cd fred ; ant -Dlib.contrib.get=true -Dtest.skip=true ; cd .. ; fi
 
 script: ant

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ cache:
   apt: true
   directories:
   - fred/
-  - fred/lib/
 
 before_install:
   - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; else cd fred ; git pull ; cd .. ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ cache:
 before_install:
   - cd "$TRAVIS_BUILD_DIR"/..
   - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; else cd fred ; git pull ; cd .. ; fi
-  - if [ ! -e fred/lib/bcprov-jdk15on-154.jar ]; then cd fred/lib ; wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; ln -s bcprov-jdk15on-154.jar bcprov.jar; cd ../.. ; fi
+  - if [ ! -e fred/lib/bcprov-jdk15on-154.jar ]; then cd fred/lib ; wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; cd ../.. ; fi
+  - cd fred/lib ; rm -f bcprov.jar ; ln -s bcprov-jdk15on-154.jar bcprov.jar ; cd ../..
   - cd fred && ant clean && ant -Dlib.contrib.get=true -Dtest.skip=true && cd ..
   - cd "$TRAVIS_BUILD_DIR"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 before_install:
   - cd "$TRAVIS_BUILD_DIR"/..
   - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; else cd fred ; git pull ; cd .. ; fi
-  - if [ ! -e fred/lib/bcprov-jdk15on-154.jar ]; then cd fred/lib ; wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; cd ../.. ; fi
+  - if [ ! -e fred/lib/bcprov-jdk15on-154.jar ]; then cd fred/lib ; wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; ln -s bcprov-jdk15on-154.jar bcprov.jar; cd ../.. ; fi
   - cd fred && ant clean && ant -Dlib.contrib.get=true -Dtest.skip=true && cd ..
   - cd "$TRAVIS_BUILD_DIR"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ cache:
   - fred/lib/
 
 before_install:
+  - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; else cd fred ; git pull ; cd .. ; fi
   - mkdir -p fred/lib/freenet/
   - if [ ! -e fred/lib/bcprov-jdk15on-154.jar ]; then cd fred/lib ; wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; cd ../.. ; fi
-  - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; else cd fred ; git pull ; cd .. ; fi
   - cd fred && ant clean && ant -Dlib.contrib.get=true -Dtest.skip=true && cd ..
 
 script: ant

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,17 @@ addons:
 cache:
   apt: true
   directories:
-  - lib/
+  - fred/
+  - fred/lib/
 
 before_install:
-  - mkdir -p lib/freenet/ && cd lib/ && if [ ! -e bcprov-jdk15on-154.jar ]; then wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; fi ; cd ..
+  - mkdir -p fred/lib/freenet/
+  - if [ ! -e fred/lib/bcprov-jdk15on-154.jar ]; then cd fred/lib ; wget -c --no-check-certificate https://bouncycastle.org/download/bcprov-jdk15on-154.jar; cd ../.. ; fi
+  - if [ ! -e fred/src ]; then git clone https://github.com/freenet/fred.git --branch next --single-branch fred ; fi
+  - cd fred ; git pull ; cd ..
+  - if [ ! -e fred/dist/freenet.jar ]; then cd fred ; ant -Dlib.contrib.get=true -Dtest.skip=true ; cd .. ; fi
 
-script: ant -Dlib.contrib.get=true
+script: ant
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 cache:
   apt: true
   directories:
-  - "$TRAVIS_BUILD_DIR"/../fred/
+  - $TRAVIS_BUILD_DIR/../fred/
 
 before_install:
   - cd "$TRAVIS_BUILD_DIR"/..

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ addons:
     - ant-optional
     - junit4
     - libhamcrest-java
+  # TODO: Code quality: Remove this workaround for https://github.com/travis-ci/travis-ci/issues/5227
+  hostname: freenet-plugin-WebOfTrust
 
 cache:
   apt: true


### PR DESCRIPTION
https://bugs.freenetproject.org/view.php?id=6760

The errors are because Travis CI runs on Ubuntu 12.04, whose junit package is too old.
The obvious fix may be to use Gradle.